### PR TITLE
remove ro.vendor.build.svn sysprop

### DIFF
--- a/device-oriole.mk
+++ b/device-oriole.mk
@@ -312,3 +312,5 @@ PRODUCT_VENDOR_PROPERTIES += \
 PRODUCT_PRODUCT_PROPERTIES += \
     ro.quick_start.oem_id=00e0 \
     ro.quick_start.device_id=oriole
+
+PRODUCT_VENDOR_PROPERTIES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_VENDOR_PROPERTIES))

--- a/device-raven.mk
+++ b/device-raven.mk
@@ -322,3 +322,5 @@ PRODUCT_VENDOR_PROPERTIES += \
 PRODUCT_PRODUCT_PROPERTIES += \
     ro.quick_start.oem_id=00e0 \
     ro.quick_start.device_id=raven
+
+PRODUCT_VENDOR_PROPERTIES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_VENDOR_PROPERTIES))


### PR DESCRIPTION
Value of ro.vendor.build.svn in stock OS image used by adevtool might not match the value specified here, e.g. when base AOSP tag doesn't match the tag that was used for stock OS build.

adevtool automatically adds missing properties, i.e. removal of ro.vendor.build.svn from here means that ro.vendor.build.svn sysprop value from stock OS image will be used instead.